### PR TITLE
Improve pagination validation and handler error handling

### DIFF
--- a/src/main/java/com/example/bootcamp/domain/model/BootcampPageRequest.java
+++ b/src/main/java/com/example/bootcamp/domain/model/BootcampPageRequest.java
@@ -1,8 +1,24 @@
 package com.example.bootcamp.domain.model;
 
+import java.util.Objects;
+
 public record BootcampPageRequest(
         int page,
         int size,
         BootcampSortField sortBy,
         SortDirection direction
-) {}
+) {
+    private static final String INVALID_PAGE = "invalid.pagination.page";
+    private static final String INVALID_SIZE = "invalid.pagination.size";
+
+    public BootcampPageRequest {
+        if (page < 0) {
+            throw new IllegalArgumentException(INVALID_PAGE);
+        }
+        if (size <= 0) {
+            throw new IllegalArgumentException(INVALID_SIZE);
+        }
+        sortBy = Objects.requireNonNull(sortBy, "invalid.pagination.sort.by");
+        direction = Objects.requireNonNull(direction, "invalid.pagination.direction");
+    }
+}

--- a/src/main/java/com/example/bootcamp/domain/usecase/ListBootcampUseCase.java
+++ b/src/main/java/com/example/bootcamp/domain/usecase/ListBootcampUseCase.java
@@ -1,7 +1,5 @@
 package com.example.bootcamp.domain.usecase;
 
-import com.example.bootcamp.domain.error.DomainException;
-import com.example.bootcamp.domain.error.ErrorCodes;
 import com.example.bootcamp.domain.model.BootcampPageRequest;
 import com.example.bootcamp.domain.model.PaginatedBootcamp;
 import com.example.bootcamp.infrastructure.repository.SpringDataBootcampRepository;
@@ -16,12 +14,6 @@ public class ListBootcampUseCase {
     }
 
     public Mono<PaginatedBootcamp> execute(BootcampPageRequest request) {
-        if (request.size() <= 0) {
-            return Mono.error(new DomainException(ErrorCodes.VALIDATION_ERROR, "invalid.pagination.size"));
-        }
-        if (request.page() < 0) {
-            return Mono.error(new DomainException(ErrorCodes.VALIDATION_ERROR, "invalid.pagination.page"));
-        }
         return repository.findAll(request);
     }
 }


### PR DESCRIPTION
## Summary
- validate pagination inputs in `BootcampPageRequest` and reuse across the application
- simplify `ListBootcampUseCase` by removing redundant size/page guards now enforced by the request object
- refactor `BootcampHandler` pagination parsing to provide clearer validation errors and streamline validation utilities

## Testing
- ./gradlew test *(fails: unable to download dependencies due to 403 responses from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68e5755b0a948320ad446f1203c90bd6