### PR TITLE
test: increase coverage for mapper and pagination validations

### DIFF
--- a/src/test/java/com/example/bootcamp/domain/model/BootcampPageRequestTest.java
+++ b/src/test/java/com/example/bootcamp/domain/model/BootcampPageRequestTest.java
@@ -1,0 +1,54 @@
+package com.example.bootcamp.domain.model;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BootcampPageRequestTest {
+
+    @Test
+    void createBootcampPageRequest() {
+        BootcampPageRequest request = new BootcampPageRequest(1, 20, BootcampSortField.NAME, SortDirection.ASC);
+
+        assertEquals(1, request.page());
+        assertEquals(20, request.size());
+        assertEquals(BootcampSortField.NAME, request.sortBy());
+        assertEquals(SortDirection.ASC, request.direction());
+    }
+
+    @Test
+    void createBootcampPageRequest_invalidPage() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+                new BootcampPageRequest(-1, 10, BootcampSortField.NAME, SortDirection.ASC)
+        );
+
+        assertEquals("invalid.pagination.page", exception.getMessage());
+    }
+
+    @Test
+    void createBootcampPageRequest_invalidSize() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () ->
+                new BootcampPageRequest(0, 0, BootcampSortField.NAME, SortDirection.ASC)
+        );
+
+        assertEquals("invalid.pagination.size", exception.getMessage());
+    }
+
+    @Test
+    void createBootcampPageRequest_invalidSortField() {
+        NullPointerException exception = assertThrows(NullPointerException.class, () ->
+                new BootcampPageRequest(0, 10, null, SortDirection.ASC)
+        );
+
+        assertEquals("invalid.pagination.sort.by", exception.getMessage());
+    }
+
+    @Test
+    void createBootcampPageRequest_invalidSortDirection() {
+        NullPointerException exception = assertThrows(NullPointerException.class, () ->
+                new BootcampPageRequest(0, 10, BootcampSortField.NAME, null)
+        );
+
+        assertEquals("invalid.pagination.direction", exception.getMessage());
+    }
+}

--- a/src/test/java/com/example/bootcamp/infrastructure/mapper/BootcampMapperTest.java
+++ b/src/test/java/com/example/bootcamp/infrastructure/mapper/BootcampMapperTest.java
@@ -1,0 +1,70 @@
+package com.example.bootcamp.infrastructure.mapper;
+
+import com.example.bootcamp.domain.model.Bootcamp;
+import com.example.bootcamp.infrastructure.repository.documents.BootcampEntity;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BootcampMapperTest {
+
+    @Test
+    void toDomain_mapsAllFields() {
+        LocalDate launchDate = LocalDate.of(2024, 5, 10);
+        Bootcamp domain = BootcampMapper.toDomain(
+                "bootcamp-123",
+                "Java Fundamentals",
+                "description",
+                launchDate,
+                8,
+                List.of("c1", "c2")
+        );
+
+        assertEquals("bootcamp-123", domain.id());
+        assertEquals("Java Fundamentals", domain.name());
+        assertEquals("description", domain.description());
+        assertEquals(launchDate, domain.launchDate());
+        assertEquals(8, domain.durationWeeks());
+        assertEquals(List.of("c1", "c2"), domain.capabilities());
+    }
+
+    @Test
+    void toDomain_throwsWhenDurationIsNull() {
+        IllegalStateException exception = assertThrows(
+                IllegalStateException.class,
+                () -> BootcampMapper.toDomain(
+                        "id",
+                        "name",
+                        "description",
+                        LocalDate.now(),
+                        null,
+                        List.of("capability")
+                )
+        );
+
+        assertEquals("bootcamp.duration.null", exception.getMessage());
+    }
+
+    @Test
+    void toEntity_copiesPrimitiveFields() {
+        Bootcamp bootcamp = new Bootcamp(
+                "bootcamp-456",
+                "Java Advanced",
+                "advanced description",
+                LocalDate.of(2025, 1, 1),
+                12,
+                List.of("c1")
+        );
+
+        BootcampEntity entity = BootcampMapper.toEntity(bootcamp);
+
+        assertEquals("bootcamp-456", entity.getId());
+        assertEquals("Java Advanced", entity.getName());
+        assertEquals("advanced description", entity.getDescription());
+        assertEquals(LocalDate.of(2025, 1, 1), entity.getLaunchDate());
+        assertEquals(12, entity.getDurationWeeks());
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for BootcampPageRequest validation rules
- cover BootcampMapper conversions for both domain and entity projections

## Testing
- `./gradlew test` *(fails: dependency download blocked by 403 from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68e57a7e21588320aff79d4b32e62bc8