### PR TITLE
Refactor column name literals in bootcamp repository

### DIFF
--- a/src/main/java/com/example/bootcamp/infrastructure/repository/SpringDataBootcampRepository.java
+++ b/src/main/java/com/example/bootcamp/infrastructure/repository/SpringDataBootcampRepository.java
@@ -24,6 +24,17 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static com.example.bootcamp.infrastructure.repository.support.BootcampRepositorySupport.BASE_SELECT;
+import static com.example.bootcamp.infrastructure.repository.support.BootcampRepositorySupport.COLUMN_BOOTCAMP_DESCRIPTION;
+import static com.example.bootcamp.infrastructure.repository.support.BootcampRepositorySupport.COLUMN_BOOTCAMP_DURATION_WEEKS;
+import static com.example.bootcamp.infrastructure.repository.support.BootcampRepositorySupport.COLUMN_BOOTCAMP_ID;
+import static com.example.bootcamp.infrastructure.repository.support.BootcampRepositorySupport.COLUMN_BOOTCAMP_LAUNCH_DATE;
+import static com.example.bootcamp.infrastructure.repository.support.BootcampRepositorySupport.COLUMN_BOOTCAMP_NAME;
+import static com.example.bootcamp.infrastructure.repository.support.BootcampRepositorySupport.COLUMN_CAPABILITY_COUNT;
+import static com.example.bootcamp.infrastructure.repository.support.BootcampRepositorySupport.COLUMN_CAPABILITY_DESCRIPTION;
+import static com.example.bootcamp.infrastructure.repository.support.BootcampRepositorySupport.COLUMN_CAPABILITY_ID;
+import static com.example.bootcamp.infrastructure.repository.support.BootcampRepositorySupport.COLUMN_CAPABILITY_NAME;
+import static com.example.bootcamp.infrastructure.repository.support.BootcampRepositorySupport.COLUMN_TECHNOLOGY_ID;
+import static com.example.bootcamp.infrastructure.repository.support.BootcampRepositorySupport.COLUMN_TECHNOLOGY_NAME;
 import static com.example.bootcamp.infrastructure.repository.support.BootcampRepositorySupport.PAGINATED_SELECT_TEMPLATE;
 
 import com.example.bootcamp.infrastructure.repository.support.BootcampRepositorySupport.BootcampCapabilityRow;
@@ -133,29 +144,29 @@ public class SpringDataBootcampRepository {
 
   private BootcampCapabilityRow mapRow(Row row, RowMetadata metadata) {
     return new BootcampCapabilityRow(
-        row.get("bootcamp_id", String.class),
-        row.get("bootcamp_name", String.class),
-        row.get("bootcamp_description", String.class),
-        row.get("bootcamp_launch_date", LocalDate.class),
-        row.get("bootcamp_duration_weeks", Integer.class),
-        row.get("capability_id", String.class)
+        row.get(COLUMN_BOOTCAMP_ID, String.class),
+        row.get(COLUMN_BOOTCAMP_NAME, String.class),
+        row.get(COLUMN_BOOTCAMP_DESCRIPTION, String.class),
+        row.get(COLUMN_BOOTCAMP_LAUNCH_DATE, LocalDate.class),
+        row.get(COLUMN_BOOTCAMP_DURATION_WEEKS, Integer.class),
+        row.get(COLUMN_CAPABILITY_ID, String.class)
     );
   }
 
   private BootcampCapabilityTechnologyDetailRow mapPagedRow(Row row, RowMetadata metadata) {
-    Number capabilityCount = row.get("capability_count", Number.class);
+    Number capabilityCount = row.get(COLUMN_CAPABILITY_COUNT, Number.class);
     return new BootcampCapabilityTechnologyDetailRow(
-        row.get("bootcamp_id", String.class),
-        row.get("bootcamp_name", String.class),
-        row.get("bootcamp_description", String.class),
-        row.get("bootcamp_launch_date", LocalDate.class),
-        row.get("bootcamp_duration_weeks", Integer.class),
+        row.get(COLUMN_BOOTCAMP_ID, String.class),
+        row.get(COLUMN_BOOTCAMP_NAME, String.class),
+        row.get(COLUMN_BOOTCAMP_DESCRIPTION, String.class),
+        row.get(COLUMN_BOOTCAMP_LAUNCH_DATE, LocalDate.class),
+        row.get(COLUMN_BOOTCAMP_DURATION_WEEKS, Integer.class),
         capabilityCount == null ? 0 : capabilityCount.intValue(),
-        row.get("capability_id", String.class),
-        row.get("capability_name", String.class),
-        row.get("capability_description", String.class),
-        row.get("technology_id", String.class),
-        row.get("technology_name", String.class)
+        row.get(COLUMN_CAPABILITY_ID, String.class),
+        row.get(COLUMN_CAPABILITY_NAME, String.class),
+        row.get(COLUMN_CAPABILITY_DESCRIPTION, String.class),
+        row.get(COLUMN_TECHNOLOGY_ID, String.class),
+        row.get(COLUMN_TECHNOLOGY_NAME, String.class)
     );
   }
 

--- a/src/main/java/com/example/bootcamp/infrastructure/repository/support/BootcampRepositorySupport.java
+++ b/src/main/java/com/example/bootcamp/infrastructure/repository/support/BootcampRepositorySupport.java
@@ -7,6 +7,18 @@ public final class BootcampRepositorySupport {
   private BootcampRepositorySupport() {
   }
 
+  public static final String COLUMN_BOOTCAMP_ID = "bootcamp_id";
+  public static final String COLUMN_BOOTCAMP_NAME = "bootcamp_name";
+  public static final String COLUMN_BOOTCAMP_DESCRIPTION = "bootcamp_description";
+  public static final String COLUMN_BOOTCAMP_LAUNCH_DATE = "bootcamp_launch_date";
+  public static final String COLUMN_BOOTCAMP_DURATION_WEEKS = "bootcamp_duration_weeks";
+  public static final String COLUMN_CAPABILITY_COUNT = "capability_count";
+  public static final String COLUMN_CAPABILITY_ID = "capability_id";
+  public static final String COLUMN_CAPABILITY_NAME = "capability_name";
+  public static final String COLUMN_CAPABILITY_DESCRIPTION = "capability_description";
+  public static final String COLUMN_TECHNOLOGY_ID = "technology_id";
+  public static final String COLUMN_TECHNOLOGY_NAME = "technology_name";
+
   public static final String BASE_SELECT = """
       SELECT b.id AS bootcamp_id,
              b.name AS bootcamp_name,


### PR DESCRIPTION
## Summary
- add named column constants in `BootcampRepositorySupport`
- update `SpringDataBootcampRepository` row mappers to use the shared constants

## Testing
- `./gradlew test` *(fails: Unable to download dependencies from Maven Central due to HTTP 403 responses)*

------
https://chatgpt.com/codex/tasks/task_e_68e69f62120883208f48e6421f7f3417