### PR TITLE
feat: send bootcamp reports when creating bootcamps

### DIFF
--- a/src/main/java/com/example/bootcamp/application/config/UseCasesConfig.java
+++ b/src/main/java/com/example/bootcamp/application/config/UseCasesConfig.java
@@ -3,6 +3,7 @@ package com.example.bootcamp.application.config;
 import com.example.bootcamp.domain.usecase.CreateBootcampUseCase;
 import com.example.bootcamp.domain.usecase.DeleteBootcampUseCase;
 import com.example.bootcamp.domain.usecase.ListBootcampUseCase;
+import com.example.bootcamp.infrastructure.client.BootcampReportClient;
 import com.example.bootcamp.infrastructure.repository.SpringDataBootcampRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,8 +12,8 @@ import org.springframework.context.annotation.Configuration;
 public class UseCasesConfig {
 
     @Bean
-    public CreateBootcampUseCase createBootcampUseCase(SpringDataBootcampRepository repo) {
-        return new CreateBootcampUseCase(repo);
+    public CreateBootcampUseCase createBootcampUseCase(SpringDataBootcampRepository repo, BootcampReportClient client) {
+        return new CreateBootcampUseCase(repo, client);
     }
 
     @Bean

--- a/src/main/java/com/example/bootcamp/infrastructure/client/BootcampReportClient.java
+++ b/src/main/java/com/example/bootcamp/infrastructure/client/BootcampReportClient.java
@@ -1,0 +1,87 @@
+package com.example.bootcamp.infrastructure.client;
+
+import com.example.bootcamp.domain.model.Bootcamp;
+import com.example.bootcamp.domain.model.BootcampSummary;
+import com.example.bootcamp.domain.model.CapabilitySummary;
+import com.example.bootcamp.domain.model.TechnologySummary;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class BootcampReportClient {
+
+  private final WebClient webClient;
+  private final String reportPath;
+
+  public BootcampReportClient(
+      WebClient.Builder webClientBuilder,
+      @Value("${app.bootcamp-report.base-url:http://localhost:8085}") String baseUrl,
+      @Value("${app.bootcamp-report.path:/bootcamp-reports}") String reportPath
+  ) {
+    this.webClient = webClientBuilder.baseUrl(baseUrl).build();
+    this.reportPath = reportPath;
+  }
+
+  public Mono<Void> sendBootcampReport(Bootcamp bootcamp, BootcampSummary summary) {
+    BootcampReportRequest request = BootcampReportRequest.from(bootcamp, summary);
+    return webClient.post()
+        .uri(reportPath)
+        .bodyValue(request)
+        .retrieve()
+        .bodyToMono(Void.class);
+  }
+
+  private record BootcampReportRequest(
+      String bootcampId,
+      String name,
+      String description,
+      List<CapabilityPayload> capacities,
+      List<TechnologyPayload> technologies,
+      List<ParticipantPayload> participants
+  ) {
+    private static BootcampReportRequest from(Bootcamp bootcamp, BootcampSummary summary) {
+      List<CapabilityPayload> capabilityPayloads = summary.capabilities().stream()
+          .map(capability -> new CapabilityPayload(
+              capability.id(),
+              capability.name(),
+              capability.description()
+          ))
+          .toList();
+
+      Map<String, TechnologySummary> technologies = new LinkedHashMap<>();
+      for (CapabilitySummary capability : summary.capabilities()) {
+        for (TechnologySummary technology : capability.technologies()) {
+          technologies.putIfAbsent(technology.id(), technology);
+        }
+      }
+
+      List<TechnologyPayload> technologyPayloads = technologies.values().stream()
+          .map(technology -> new TechnologyPayload(technology.id(), technology.name()))
+          .toList();
+
+      return new BootcampReportRequest(
+          bootcamp.id(),
+          bootcamp.name(),
+          bootcamp.description(),
+          capabilityPayloads,
+          technologyPayloads,
+          List.of()
+      );
+    }
+  }
+
+  private record CapabilityPayload(String id, String name, String description) {
+  }
+
+  private record TechnologyPayload(String id, String name) {
+  }
+
+  private record ParticipantPayload(String id, String fullName, String email) {
+  }
+}

--- a/src/main/java/com/example/bootcamp/infrastructure/repository/support/BootcampRepositorySupport.java
+++ b/src/main/java/com/example/bootcamp/infrastructure/repository/support/BootcampRepositorySupport.java
@@ -88,6 +88,26 @@ public final class BootcampRepositorySupport {
       ORDER BY %s %s, pb.id ASC, c.name ASC, c.id ASC, t.name ASC, t.id ASC
       """;
 
+  public static final String SELECT_BOOTCAMP_DETAILS_BY_ID = String.format("""
+      SELECT b.id AS bootcamp_id,
+             b.name AS bootcamp_name,
+             b.description AS bootcamp_description,
+             b.launch_date AS bootcamp_launch_date,
+             b.duration_weeks AS bootcamp_duration_weeks,
+             c.id AS capability_id,
+             c.name AS capability_name,
+             c.description AS capability_description,
+             t.id AS technology_id,
+             t.name AS technology_name
+      FROM bootcamp.bootcamps b
+      LEFT JOIN bootcamp.bootcamp_capability bc ON bc.bootcamp_id = b.id
+      LEFT JOIN bootcamp.capabilities c ON c.id = bc.capability_id
+      LEFT JOIN bootcamp.capability_technology ct ON ct.capability_id = c.id
+      LEFT JOIN bootcamp.technologies t ON t.id = ct.technology_id
+      WHERE b.id = :%s
+      ORDER BY b.id ASC, c.name ASC, c.id ASC, t.name ASC, t.id ASC
+      """, PARAM_BOOTCAMP_ID);
+
   public static record BootcampCapabilityRow(
       String bootcampId,
       String bootcampName,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,4 +16,7 @@ app:
     database: bootcamp
     username: root
     password: 1234
+  bootcamp-report:
+    base-url: http://localhost:8085
+    path: /bootcamp-reports
 

--- a/src/test/java/com/example/bootcamp/domain/usecase/CreateBootcampUseCaseTest.java
+++ b/src/test/java/com/example/bootcamp/domain/usecase/CreateBootcampUseCaseTest.java
@@ -2,6 +2,10 @@ package com.example.bootcamp.domain.usecase;
 
 import com.example.bootcamp.domain.error.DomainException;
 import com.example.bootcamp.domain.model.Bootcamp;
+import com.example.bootcamp.domain.model.BootcampSummary;
+import com.example.bootcamp.domain.model.CapabilitySummary;
+import com.example.bootcamp.domain.model.TechnologySummary;
+import com.example.bootcamp.infrastructure.client.BootcampReportClient;
 import com.example.bootcamp.infrastructure.repository.SpringDataBootcampRepository;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -9,6 +13,7 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -16,11 +21,24 @@ class CreateBootcampUseCaseTest {
   @Test
   void create_ok(){
     SpringDataBootcampRepository repo = Mockito.mock(SpringDataBootcampRepository.class);
+    BootcampReportClient reportClient = Mockito.mock(BootcampReportClient.class);
     Mockito.when(repo.findByName("My Bootcamp")).thenReturn(Mono.empty());
     Mockito.when(repo.save(Mockito.any(Bootcamp.class))).thenAnswer(i -> Mono.just((Bootcamp) i.getArguments()[0]));
-    var uc = new CreateBootcampUseCase(repo);
-    var capabilities = java.util.List.of("c1", "c2");
     var launchDate = LocalDate.of(2024, 2, 1);
+    Mockito.when(repo.findSummaryById(Mockito.anyString())).thenAnswer(invocation -> {
+      String id = invocation.getArgument(0, String.class);
+      CapabilitySummary capability = new CapabilitySummary(
+          "c1",
+          "Backend",
+          "Server",
+          List.of(new TechnologySummary("t1", "Java")),
+          1
+      );
+      return Mono.just(new BootcampSummary(id, "My Bootcamp", "des", launchDate, 8, List.of(capability), 1));
+    });
+    Mockito.when(reportClient.sendBootcampReport(Mockito.any(), Mockito.any())).thenReturn(Mono.empty());
+    var uc = new CreateBootcampUseCase(repo, reportClient);
+    var capabilities = java.util.List.of("c1", "c2");
     StepVerifier.create(uc.execute("My Bootcamp", "des", launchDate, 8, capabilities))
         .assertNext(bootcamp -> {
           assertNotNull(bootcamp.id());
@@ -30,13 +48,15 @@ class CreateBootcampUseCaseTest {
           assertEquals(capabilities, bootcamp.capabilities());
         })
         .verifyComplete();
+    Mockito.verify(reportClient).sendBootcampReport(Mockito.any(Bootcamp.class), Mockito.any(BootcampSummary.class));
   }
 
   @Test
   void create_conflict_when_name_exists(){
     SpringDataBootcampRepository repo = Mockito.mock(SpringDataBootcampRepository.class);
+    BootcampReportClient reportClient = Mockito.mock(BootcampReportClient.class);
     Mockito.when(repo.findByName("My Bootcamp")).thenReturn(Mono.just(new Bootcamp("id", "My Bootcamp", "des", LocalDate.of(2024,1,1), 10, java.util.List.of("c1","c2"))));
-    var uc = new CreateBootcampUseCase(repo);
+    var uc = new CreateBootcampUseCase(repo, reportClient);
 
     StepVerifier.create(uc.execute("My Bootcamp", "des", LocalDate.of(2024, 1, 1), 10, java.util.List.of("c1", "c2")))
         .expectErrorSatisfies(error -> {
@@ -49,8 +69,9 @@ class CreateBootcampUseCaseTest {
   @Test
   void create_validation_error_when_capabilities_invalid(){
     SpringDataBootcampRepository repo = Mockito.mock(SpringDataBootcampRepository.class);
+    BootcampReportClient reportClient = Mockito.mock(BootcampReportClient.class);
     Mockito.when(repo.findByName("My Bootcamp")).thenReturn(Mono.empty());
-    var uc = new CreateBootcampUseCase(repo);
+    var uc = new CreateBootcampUseCase(repo, reportClient);
 
     StepVerifier.create(uc.execute("My Bootcamp", "des", LocalDate.of(2024, 1, 1), 5, java.util.List.of()))
         .expectErrorSatisfies(error -> {


### PR DESCRIPTION
## Summary
- add a WebClient-based BootcampReportClient that posts bootcamp reports to the external service
- update the create bootcamp flow to fetch capability/technology details and trigger the report after persisting
- expose repository support for detailed summaries, wire the new use case dependency, and cover the behaviour in tests

## Testing
- ./gradlew test *(fails: unable to download dependencies from Maven Central, HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e7d21944e88320aee1447366776415